### PR TITLE
Update HmacSigningCredentials.cs

### DIFF
--- a/source/IdentityModel.Net45/Tokens/HmacSigningCredentials.cs
+++ b/source/IdentityModel.Net45/Tokens/HmacSigningCredentials.cs
@@ -43,7 +43,7 @@ namespace IdentityModel.Tokens
                 case 64:
                     return Algorithms.HmacSha512Signature;
                 default:
-                    throw new InvalidOperationException("Unsupported key lenght");
+                    throw new InvalidOperationException("Unsupported key length");
             }
         }
 


### PR DESCRIPTION
Typo in CreateSignatureAlgorithm -> InvalidOperationException message. Changed from "Unsupported key lenght" to "Unsupported key length".
