### PR TITLE
Changed Portable project to target more-friendly Profile259

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -69,10 +69,10 @@ task CreateNuGetPackage -depends Compile {
 	new-item $dist_directory\lib\net45 -type directory
 	copy-item $output_directory\net45\IdentityModel.Net45.dll $dist_directory\lib\net45\
 	copy-item $output_directory\net45\IdentityModel.Net45.pdb $dist_directory\lib\net45\
-	
-	new-item $dist_directory\lib\portable-net45+win8+wpa81 -type directory
-	copy-item $output_directory\portable\IdentityModel.Portable.dll $dist_directory\lib\portable-net45+win8+wpa81\
-	copy-item $output_directory\portable\IdentityModel.Portable.pdb $dist_directory\lib\portable-net45+win8+wpa81\
+
+	new-item $dist_directory\lib\portable-net45+wp80+win8+wpa81 -type directory
+	copy-item $output_directory\portable\IdentityModel.Portable.dll $dist_directory\lib\portable-net45+wp80+win8+wpa81\
+	copy-item $output_directory\portable\IdentityModel.Portable.pdb $dist_directory\lib\portable-net45+wp80+win8+wpa81\
 	
 	exec { . $nuget_path pack $dist_directory\IdentityModel.nuspec -BasePath $dist_directory -o $dist_directory -version $packageVersion }
 }

--- a/source/IdentityModel.Portable/IdentityModel.Portable.csproj
+++ b/source/IdentityModel.Portable/IdentityModel.Portable.csproj
@@ -13,7 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -40,12 +40,29 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\portable-net45+wp80+win8+wpa81+aspnetcore50\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\IdentityModel.Shared\IdentityModel.Shared.projitems" Label="Shared" Condition="Exists('..\IdentityModel.Shared\IdentityModel.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/IdentityModel.Portable/packages.config
+++ b/source/IdentityModel.Portable/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="portable-net45+win+wpa81" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="portable-net45+win8+wpa81" />
 </packages>

--- a/source/IdentityModel.nuspec
+++ b/source/IdentityModel.nuspec
@@ -25,12 +25,13 @@
     </frameworkAssemblies>
 
     <dependencies>
-      <group targetFramework="portable-net45+win+wpa81">
-      	<dependency id="Newtonsoft.Json" version="6.0.8" />
+      <group targetFramework="portable-net45+wp80+win8+wpa81">
+        <dependency id="Newtonsoft.Json" version="6.0.8" />
+        <dependency id="Microsoft.Net.Http" version="2.2.28"/>
       </group>
 
       <group targetFramework="net45">
-      	<dependency id="Newtonsoft.Json" version="6.0.8" />
+        <dependency id="Newtonsoft.Json" version="6.0.8" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This allows IdentityModel to target Xamarin.Android, Xamarin.iOS and also PCL projects used by both of them.

In order to support Profile78 and Profile259 the Portable project has to take a dependency on Microsoft.Net.Http, like the old IdentityModel.Client did, is this ok?

Also, I wasn't sure if I had to bump the patch version myself or not.

Closes #9 
