### PR TITLE
Relaxed inner handler parameter type of UserInfoClient

### DIFF
--- a/source/IdentityModel.Shared/Client/TokenClient.cs
+++ b/source/IdentityModel.Shared/Client/TokenClient.cs
@@ -35,12 +35,12 @@ namespace IdentityModel.Client
             : this(address, new HttpClientHandler())
         { }
 
-        public TokenClient(string address, HttpMessageHandler innerHttpClientHandler)
+        public TokenClient(string address, HttpMessageHandler innerHttpMessageHandler)
         {
             if (address == null) throw new ArgumentNullException("address");
-            if (innerHttpClientHandler == null) throw new ArgumentNullException("innerHttpClientHandler");
+            if (innerHttpMessageHandler == null) throw new ArgumentNullException("innerHttpMessageHandler");
             
-            _client = new HttpClient(innerHttpClientHandler)
+            _client = new HttpClient(innerHttpMessageHandler)
             {
                 BaseAddress = new Uri(address)
             };
@@ -56,12 +56,12 @@ namespace IdentityModel.Client
             : this(address, clientId, string.Empty, new HttpClientHandler(), style)
         { }
 
-        public TokenClient(string address, string clientId, HttpMessageHandler innerHttpClientHandler)
-            : this(address, clientId, string.Empty, innerHttpClientHandler, AuthenticationStyle.PostValues)
+        public TokenClient(string address, string clientId, HttpMessageHandler innerHttpMessageHandler)
+            : this(address, clientId, string.Empty, innerHttpMessageHandler, AuthenticationStyle.PostValues)
         { }
 
-        public TokenClient(string address, string clientId, string clientSecret, HttpMessageHandler innerHttpClientHandler, AuthenticationStyle style = AuthenticationStyle.BasicAuthentication)
-            : this(address, innerHttpClientHandler)
+        public TokenClient(string address, string clientId, string clientSecret, HttpMessageHandler innerHttpMessageHandler, AuthenticationStyle style = AuthenticationStyle.BasicAuthentication)
+            : this(address, innerHttpMessageHandler)
         {
             if (string.IsNullOrEmpty(clientId)) throw new ArgumentNullException("ClientId");
 

--- a/source/IdentityModel.Shared/Client/UserInfoClient.cs
+++ b/source/IdentityModel.Shared/Client/UserInfoClient.cs
@@ -29,7 +29,7 @@ namespace IdentityModel.Client
             : this(endpoint, token, new HttpClientHandler())
         { }
 
-        public UserInfoClient(Uri endpoint, string token, HttpClientHandler innerHttpClientHandler)
+        public UserInfoClient(Uri endpoint, string token, HttpMessageHandler innerHttpMessageHandler)
         {
             if (endpoint == null)
                 throw new ArgumentNullException("endpoint");
@@ -37,10 +37,10 @@ namespace IdentityModel.Client
             if (string.IsNullOrEmpty(token))
                 throw new ArgumentNullException("token");
 
-            if (innerHttpClientHandler == null)
-                throw new ArgumentNullException("innerHttpClientHandler");
+            if (innerHttpMessageHandler == null)
+                throw new ArgumentNullException("innerHttpMessageHandler");
 
-            _client = new HttpClient(innerHttpClientHandler)
+            _client = new HttpClient(innerHttpMessageHandler)
             {
                 BaseAddress = endpoint
             };


### PR DESCRIPTION
This will allow an HttpMessageHandler instance to be passed into UserInfoClient, as opposed to an HttpClientHandler, which will relax the restriction on consumers and also make it more consistent with the constructor parameters on TokenClient.

Thanks,

Mark
