### PR TITLE
Add support for "private_key_jwt" client authentication

### DIFF
--- a/source/IdentityModel.Net45/Client/TokenClientExtensions.cs
+++ b/source/IdentityModel.Net45/Client/TokenClientExtensions.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * Copyright 2014, 2015 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using IdentityModel.Tokens;
+
+namespace IdentityModel.Client
+{
+    public static partial class TokenClientExtensions
+    {
+        public static Task<TokenResponse> RequestClientCredentialsAssertionAsync(this TokenClient client, X509Certificate2 certificate, string scope = null, object extra = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var fields = new Dictionary<string, string>
+            {
+                { OAuth2Constants.GrantType, OAuth2Constants.GrantTypes.ClientCredentials },
+                { OAuth2Constants.ClientAssertionType, OAuth2Constants.ClientAssertionTypes.JwtBearer },
+                { OAuth2Constants.ClientAssertion, ClientAssertionTokenFactory.CreateToken(client.ClientId, client.Address, certificate) }
+            };
+
+            if (!string.IsNullOrWhiteSpace(scope))
+            {
+                fields.Add(OAuth2Constants.Scope, scope);
+            }
+
+            return client.RequestAsync(Merge(client, fields, extra), cancellationToken);
+        }
+    }
+}

--- a/source/IdentityModel.Net45/IdentityModel.Net45.csproj
+++ b/source/IdentityModel.Net45/IdentityModel.Net45.csproj
@@ -36,6 +36,10 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.20622.1351, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.2.206221351\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -45,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClaimComparer.cs" />
+    <Compile Include="Client\TokenClientExtensions.cs" />
     <Compile Include="Client\UserInfoResponseExtensions.cs" />
     <Compile Include="CryptoRandom.cs" />
     <Compile Include="Extensions\ConsoleExtensions.cs" />
@@ -59,6 +64,7 @@
     <Compile Include="Principal.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tokens\AuthenticationInstantClaim.cs" />
+    <Compile Include="Tokens\ClientAssertionTokenFactory.cs" />
     <Compile Include="Tokens\DateTimeFormats.cs" />
     <Compile Include="Tokens\GenericUserNameSecurityTokenHandler.cs" />
     <Compile Include="Tokens\HmacSigningCredentials.cs" />

--- a/source/IdentityModel.Net45/Tokens/ClientAssertionTokenFactory.cs
+++ b/source/IdentityModel.Net45/Tokens/ClientAssertionTokenFactory.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * Copyright 2014, 2015 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens;
+using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
+
+namespace IdentityModel.Tokens
+{
+    public static class ClientAssertionTokenFactory
+    {
+        public static string CreateToken(string clientId, string audience, X509Certificate2 certificate, bool embedCertificate = true, DateTime? nowOverride = null)
+        {
+            var now = (nowOverride ?? DateTime.Now).ToUniversalTime();
+
+            var token = new JwtSecurityToken(
+                    clientId,
+                    audience,
+                    new List<Claim>()
+                    {
+                        new Claim(JwtClaimTypes.JwtId, Guid.NewGuid().ToString()),
+                        new Claim(JwtClaimTypes.Subject, clientId),
+                        new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(now).ToString(), ClaimValueTypes.Integer64)
+                    },
+                    now,
+                    now.AddMinutes(1),
+                    new X509SigningCredentials(certificate,
+                                               SecurityAlgorithms.RsaSha256Signature,
+                                               SecurityAlgorithms.Sha256Digest)
+                );
+
+            if (embedCertificate)
+            {
+                var rawCertificate = Convert.ToBase64String(certificate.Export(X509ContentType.Cert));
+                token.Header.Add(JwtHeaderParameterNames.X5c, new[] { rawCertificate });
+            }
+
+            var handler = new JwtSecurityTokenHandler();
+            return handler.WriteToken(token);
+        }
+    }
+}

--- a/source/IdentityModel.Net45/packages.config
+++ b/source/IdentityModel.Net45/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" targetFramework="net45" />
 </packages>

--- a/source/IdentityModel.Shared/Client/OAuth2Constants.cs
+++ b/source/IdentityModel.Shared/Client/OAuth2Constants.cs
@@ -32,6 +32,8 @@ namespace IdentityModel.Client
         public const string IdentityToken = "id_token";
         public const string ClientId = "client_id";
         public const string ClientSecret = "client_secret";
+        public const string ClientAssertion = "client_assertion";
+        public const string ClientAssertionType = "client_assertion_type";
         public const string ResponseType = "response_type";
         public const string State = "state";
         public const string Nonce = "nonce";
@@ -48,6 +50,11 @@ namespace IdentityModel.Client
             public const string RefreshToken = "refresh_token";
             public const string JwtBearer = "urn:ietf:params:oauth:grant-type:jwt-bearer";
             public const string Saml2Bearer = "urn:ietf:params:oauth:grant-type:saml2-bearer";
+        }
+
+        public static class ClientAssertionTypes
+        {
+            public const string JwtBearer = "urn:ietf:params:oauth:grant-type:jwt-bearer";
         }
 
         public static class ResponseTypes

--- a/source/IdentityModel.Shared/Client/TokenClient.cs
+++ b/source/IdentityModel.Shared/Client/TokenClient.cs
@@ -31,6 +31,7 @@ namespace IdentityModel.Client
         public AuthenticationStyle AuthenticationStyle { get; set; }
         public string ClientId { get; set; }
         public string ClientSecret { get; set; }
+        public string Address { get; private set; }
 
         public TokenClient(string address)
             : this(address, new HttpClientHandler())
@@ -40,7 +41,8 @@ namespace IdentityModel.Client
         {
             if (address == null) throw new ArgumentNullException("address");
             if (innerHttpMessageHandler == null) throw new ArgumentNullException("innerHttpMessageHandler");
-            
+
+            Address = address;
             _client = new HttpClient(innerHttpMessageHandler)
             {
                 BaseAddress = new Uri(address)

--- a/source/IdentityModel.Shared/JwtClaimTypes.cs
+++ b/source/IdentityModel.Shared/JwtClaimTypes.cs
@@ -53,6 +53,7 @@ namespace IdentityModel
         public const string AccessTokenHash                     = "at_hash";
         public const string AuthorizationCodeHash               = "c_hash";
         public const string Nonce                               = "nonce";
+        public const string JwtId = "jti";
 
         // more claims
         public const string ClientId         = "client_id";


### PR DESCRIPTION
**Disclaimer:** _I don't really expect this to be merged, rather want to discuss. This isn't even tested - it just compiled._

As you see, adding this would require a dependency on `System.IdentityModel.Tokens.Jwt`. Not sure you'd want this.

What's your take on implementing the client side support - where should it go?

I already have my own very opinionated client, so I don't even need this myself, rather wanted to complete what I started.
