### PR TITLE
hold client id and send in request body for introspection

### DIFF
--- a/source/IdentityModel.Shared/Client/IntrospectionClient.cs
+++ b/source/IdentityModel.Shared/Client/IntrospectionClient.cs
@@ -26,6 +26,7 @@ namespace IdentityModel.Client
     public class IntrospectionClient
     {
         private readonly HttpClient _client;
+        private readonly string _clientId;
 
         public IntrospectionClient(string endpoint, string clientId = "", string clientSecret = "", HttpMessageHandler innerHttpMessageHandler = null)
         {
@@ -41,9 +42,13 @@ namespace IdentityModel.Client
             _client.DefaultRequestHeaders.Accept.Add(
                 new MediaTypeWithQualityHeaderValue("application/json"));
 
-            if (!string.IsNullOrWhiteSpace(clientId))
+            if (!string.IsNullOrWhiteSpace(clientId) && !string.IsNullOrWhiteSpace(clientSecret))
             {
                 _client.SetBasicAuthentication(clientId, clientSecret);
+            }
+            else if (!string.IsNullOrWhiteSpace(clientId))
+            {
+                _clientId = clientId;
             }
         }
 
@@ -71,6 +76,10 @@ namespace IdentityModel.Client
             if (!string.IsNullOrWhiteSpace(request.ClientId))
             {
                 form.Add("client_id", request.ClientId);
+            }
+            else if (!string.IsNullOrWhiteSpace(_clientId))
+            {
+                form.Add("client_id", _clientId);
             }
 
             if (!string.IsNullOrWhiteSpace(request.ClientSecret))


### PR DESCRIPTION
On correct branch now... #noob

For client certificate authentication, we need the client id passed in the body of the introspection request if passed to the `IntrospectionClient` ctor.
