### PR TITLE
Revert "Update TokenResponse constructors, to always set status response status"

### DIFF
--- a/source/IdentityModel.Shared/Client/TokenClient.cs
+++ b/source/IdentityModel.Shared/Client/TokenClient.cs
@@ -83,7 +83,7 @@ namespace IdentityModel.Client
             if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.BadRequest)
             {
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                return new TokenResponse(content, response.StatusCode, response.ReasonPhrase, response.IsSuccessStatusCode);
+                return new TokenResponse(content);
             }
             else
             {

--- a/source/IdentityModel.Shared/Client/TokenResponse.cs
+++ b/source/IdentityModel.Shared/Client/TokenResponse.cs
@@ -17,7 +17,7 @@ namespace IdentityModel.Client
         private HttpStatusCode _httpErrorstatusCode;
         private string _httpErrorReason;
 
-        public TokenResponse(string raw, HttpStatusCode statusCode = 0, string reasonPhrase = null, bool isHttpError = false) : this(statusCode, reasonPhrase, isHttpError)
+        public TokenResponse(string raw)
         {
             Raw = raw;
 
@@ -31,9 +31,9 @@ namespace IdentityModel.Client
             }
         }
 
-        public TokenResponse(HttpStatusCode statusCode, string reason, bool isHttpError = true)
+        public TokenResponse(HttpStatusCode statusCode, string reason)
         {
-            _isHttpError = isHttpError;
+            _isHttpError = true;
             _httpErrorstatusCode = statusCode;
             _httpErrorReason = reason;
         }


### PR DESCRIPTION
Reverts IdentityModel/IdentityModel#36

Didn't work - and broke existing clients. Need tests before we can change something.
