### PR TITLE
Fix the bug where unsigned  SSL certificates is used -

### DIFF
--- a/source/IdentityModel.Shared/Client/HttpClientExtensions.cs
+++ b/source/IdentityModel.Shared/Client/HttpClientExtensions.cs
@@ -20,7 +20,7 @@ namespace System.Net.Http
 
         public static void SetBearerToken(this HttpClient client, string token)
         {
-            client.SetToken("Bearer", token);
+          SetToken(client, "Bearer", token);
         }
-    }
+  }
 }


### PR DESCRIPTION
 The token is not add in the authorization header attribute with the old method when you use an unsigned SSL certificates. 
